### PR TITLE
优化windows创建数据库管理账号以及.env认证问题

### DIFF
--- a/install_pocketbase.ps1
+++ b/install_pocketbase.ps1
@@ -82,7 +82,7 @@ function Configure-AdminAccount {
         $password = Read-Host "Enter admin password (no '&' in the password and at least 10 characters)" -AsSecureString
         $BSTR = [System.Runtime.InteropServices.Marshal]::SecureStringToBSTR($password)
         $passwordText = [System.Runtime.InteropServices.Marshal]::PtrToStringAuto($BSTR)
-    } while ($passwordText.Length -lt 10) # 修正为 10，与提示一致
+    } while ($passwordText.Length -lt 10)
     
     $global:ADMIN_EMAIL = $email
     $global:ADMIN_PASSWORD = $passwordText
@@ -103,15 +103,15 @@ function Create-AdminAccount {
             exit 1
         }
         
-        # Create admin account
-        Write-Host "Creating admin account for $ADMIN_EMAIL..." -ForegroundColor Green
-        $createOutput = & $pbExe admin create $ADMIN_EMAIL $ADMIN_PASSWORD 2>&1
-        if ($LASTEXITCODE -ne 0) {
-            Write-Host "Failed to create admin account: $createOutput" -ForegroundColor Red
+        # Create or update admin account
+        Write-Host "Creating or updating admin account for $ADMIN_EMAIL..." -ForegroundColor Green
+        $createOutput = & $pbExe superuser upsert $ADMIN_EMAIL $ADMIN_PASSWORD 2>&1
+        if ($LASTEXITCODE -ne 0 -or $createOutput -notmatch "Successfully saved superuser") {
+            Write-Host "Failed to create or update admin account: $createOutput" -ForegroundColor Red
             exit 1
         }
         
-        Write-Host "Admin account created successfully!" -ForegroundColor Green
+        Write-Host "Admin account created or updated successfully!" -ForegroundColor Green
     }
     catch {
         Write-Host "Error creating admin account: $_" -ForegroundColor Red

--- a/install_pocketbase.ps1
+++ b/install_pocketbase.ps1
@@ -121,18 +121,51 @@ function Create-AdminAccount {
 
 # 7. Configure environment file
 function Configure-Environment {
-    if (-not (Test-Path ".\core\.env")) {
-        Copy-Item "env_sample" -Destination ".\core\.env"
-        Write-Host "Created new .env file from template" -ForegroundColor Green
+    $envPath = ".\core\.env"
+    
+    # Create .env if it doesn't exist
+    if (-not (Test-Path $envPath)) {
+        if (Test-Path "env_sample") {
+            Copy-Item "env_sample" -Destination $envPath
+            Write-Host "Created new .env file from template" -ForegroundColor Green
+        } else {
+            # Create a minimal .env file if env_sample is missing
+            Set-Content -Path $envPath -Value "" -Encoding UTF8
+            Write-Host "Created empty .env file (env_sample not found)" -ForegroundColor Yellow
+        }
     } else {
         Write-Host "Found existing .env file" -ForegroundColor Yellow
     }
     
-    $envContent = Get-Content ".\core\.env"
-    $envContent = $envContent -replace 'export PB_API_AUTH="[^"]*"', "export PB_API_AUTH=`"$ADMIN_EMAIL|$ADMIN_PASSWORD`""
-    Set-Content ".\core\.env" $envContent
+    # Read .env content
+    $envContent = Get-Content $envPath -Raw
     
-    Write-Host "Updated PB_API_AUTH in .env with new credentials" -ForegroundColor Green
+    # Prepare the new PB_API_AUTH line
+    $newAuthLine = "PB_API_AUTH=`"$ADMIN_EMAIL|$ADMIN_PASSWORD`""
+    
+    # Check if PB_API_AUTH exists
+    if ($envContent -match "^\s*PB_API_AUTH\s*=.*$") {
+        # Replace existing PB_API_AUTH line
+        $envContent = $envContent -replace "^\s*PB_API_AUTH\s*=.*$", $newAuthLine
+    } else {
+        # Append PB_API_AUTH if not found
+        if ($envContent -and $envContent[-1] -ne "`n") {
+            $envContent += "`n"
+        }
+        $envContent += $newAuthLine
+    }
+    
+    # Write back to .env file with UTF-8 encoding
+    Set-Content -Path $envPath -Value $envContent -Encoding UTF8
+    
+    # Verify the update
+    $updatedContent = Get-Content $envPath -Raw
+    if ($updatedContent -match [regex]::Escape($newAuthLine)) {
+        Write-Host "Successfully updated PB_API_AUTH in .env with new credentials" -ForegroundColor Green
+    } else {
+        Write-Host "Failed to update PB_API_AUTH in .env" -ForegroundColor Red
+        exit 1
+    }
 }
 
 # Main execution


### PR DESCRIPTION
我跑/core/windows_run.py的时候一直报错
://127.0.0.1:8090/api/collections/_superusers/auth-with-password
Status: 400
Data: {'data': {}, 'message': 'Failed to authenticate.', 'status': 400}
Is Abort: False
Original Error: N/A

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "C:\Users\PC\Desktop\wiseflow\core\run_task.py", line 12, in <module>
    from general_process import main_process, wiseflow_logger, pb
  File "C:\Users\PC\Desktop\wiseflow\core\general_process.py", line 19, in <module>
    pb = PbTalker(wiseflow_logger)
         ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\Users\PC\Desktop\wiseflow\core\utils\pb_api.py", line 24, in __init__
    user_data = self.client.collection("users").auth_with_password(email, password)
                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\Users\PC\AppData\Local\Programs\Python\Python311\Lib\site-packages\pocketbase\services\record_service.py", line 218, in auth_with_password
    response_data = self.client.send(
                    ^^^^^^^^^^^^^^^^^
  File "C:\Users\PC\AppData\Local\Programs\Python\Python311\Lib\site-packages\pocketbase\client.py", line 116, in send
    raise ClientResponseError(
pocketbase.errors.ClientResponseError: Message: Response error. Status code:400
URL: http://127.0.0.1:8090/api/collections/users/auth-with-password
Status: 400
Data: {'data': {}, 'message': 'Failed to authenticate.', 'status': 400}
Is Abort: False
Original Error: N/A
Error running run_task.py: Command '['C:\\Users\\PC\\AppData\\Local\\Programs\\Python\\Python311\\python.exe', 'C:\\Users\\PC\\Desktop\\wiseflow\\core\\run_task.py']' returned non-zero exit status 1.


排查发现两个问题
一个是install_pocketbase.ps1 不会将填写的邮箱和密码存入数据库
但是我对比排查发现了一下install_pocketbase.sh 发现它是有这个功能的
第二个是install_pocketbase.ps1 的邮箱和密码无法正确保存到env文件里面
 所以得优化一下install_pocketbase.ps1




