### PR TITLE
chore: replace re with regex library

### DIFF
--- a/core/agents/get_info.py
+++ b/core/agents/get_info.py
@@ -1,7 +1,8 @@
 # -*- coding: utf-8 -*-
 import asyncio
 from loguru import logger
-import os, re
+import os
+import regex as re
 from llms.openai_wrapper import openai_llm as llm
 # from core.llms.siliconflow_wrapper import sfa_llm # or other llm wrapper
 from utils.general_utils import normalize_url, url_pattern

--- a/core/requirements.txt
+++ b/core/requirements.txt
@@ -4,6 +4,7 @@ pocketbase
 pydantic
 #json_repair==0.*
 requests
+regex
 feedparser==6.0.11
 aiosqlite~=0.20
 lxml~=5.3

--- a/core/utils/general_utils.py
+++ b/core/utils/general_utils.py
@@ -1,6 +1,6 @@
 from urllib.parse import urlparse, urljoin
 import os
-import re
+import regex as re
 # import jieba
 from loguru import logger
 


### PR DESCRIPTION
Replace `re` with `regex` to avoid the issue of very long processing times for `pre_process` when the web page content is excessively long, thereby improving processing efficiency.