### PR TITLE
fix(install): 默认切回 GitHub release，atomgit 镜像当前不可用

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,27 +69,23 @@ xiaobei 由Wiseflow (原AI首席情报官）作者 bigbrother666sh 开发。
 
 一行命令，全程无需预装 Node / pnpm / git（tarball 自带 portable Node + pnpm）。脚本完成后**唯一人工输入**是填 `AWK_API_KEY`（火山方舟 Coding Plan 的 key）。
 
-**国内用户（默认走 atomgit 镜像，免梯子）：** atomgit 仓 `https://atomgit.com/wiseflow/xiaobei` 每晚从上游同步，install.sh 与 release tarball 默认都走 atomgit：
+**macOS / Linux（bash，一行命令）：**
 
 ```bash
-bash -c "$(curl -fsSL https://atomgit.com/wiseflow/xiaobei/raw/branch/master/scripts/install.sh)"
+bash -c "$(curl -fsSL https://raw.githubusercontent.com/TeamWiseFlow/xiaobei/master/scripts/install.sh)"
 ```
-
-**海外 / 有梯子用户（GitHub，加 `--github` 切回）：**
-
-```bash
-bash -c "$(curl -fsSL https://raw.githubusercontent.com/TeamWiseFlow/xiaobei/master/scripts/install.sh)" -s -- --github
-```
-
-> install.sh 默认走 atomgit 的 Gitea API 取最新 tag（atomgit 每晚自动同步上游 tag + release），全程不访问 `api.github.com`。指定版本：`export XIAOBEI_TAG=v5.6.0`。自定义镜像：`--mirror <url>` 或 `XIAOBEI_MIRROR=<url>`（自定义镜像请配 `XIAOBEI_TAG` 指定版本）。
-
-> 💡 **下载中断 / 安装失败？多试几次就好。** tarball 体积较大（~140MB），首装还要下 Firefox 反指纹浏览器（~557MB），国内网络偶发中断属正常。脚本幂等，重跑会续上已下的部分；实在卡可换 `--github` 走 GitHub release，或用 `XIAOBEI_MIRROR=<url>` 换镜像。
 
 **Windows（PowerShell）：**
 
 ```powershell
-irm https://atomgit.com/wiseflow/xiaobei/raw/branch/master/scripts/install.ps1 | iex
+irm https://raw.githubusercontent.com/TeamWiseFlow/xiaobei/master/scripts/install.ps1 | iex
 ```
+
+> install.sh / install.ps1 默认走 GitHub release 取最新 tag + 下载 tarball。指定版本：`export XIAOBEI_TAG=v5.6.0`（PowerShell：`$env:XIAOBEI_TAG="v5.6.0"`）。自定义镜像：`--mirror <url>` 或 `XIAOBEI_MIRROR=<url>`（自定义镜像请配 `XIAOBEI_TAG` 指定版本）。
+
+> 💡 **下载中断 / 安装失败？多试几次就好。** tarball 体积较大（~140MB），首装还要下 Firefox 反指纹浏览器（~557MB），网络偶发中断属正常。脚本幂等，重跑会续上已下的部分；实在卡可换 `XIAOBEI_MIRROR=<url>` 换镜像。
+
+> ℹ️ **国内镜像**：atomgit 国内镜像（`--atomgit`）正在修复中——当前其 raw 文件接口返回 SPA 页面、API 被 WAF 拦截、v5.6.0 资产未同步，暂不可用。修复后会重新作为国内默认通道。在此之前国内用户走上面的 GitHub 即可（GitHub release 的 tarball 下载走 CDN，多数国内网络可直连，慢的话多试几次）。
 
 > ⚠️ **Windows 必须装 bash**（Git Bash 或 WSL）。install.ps1 用 `tar`（Win10 1803+ 自带）解压 tarball，但 `setup-crew.sh` 是 bash 脚本，部署 crew workspace 离不开 bash。无 bash 时脚本会跳过 crew 模板部署并提示手动补跑——此时小贝团队起不来。装 Git Bash：https://git-scm.com （安装时勾选 "Add to PATH"）。
 
@@ -127,10 +123,10 @@ irm https://atomgit.com/wiseflow/xiaobei/raw/branch/master/scripts/install.ps1 |
 **已装用户重跑 install 脚本即升级**：脚本检测到 `~/.openclaw/openclaw.json` 已存在时自动走更新路线——只刷新程序目录 `~/xiaobei/`（拉新 tarball + `pnpm install --prod` 重建依赖 + 幂等刷 camoufox/weixin/awada）+ restart gateway，**不碰运行数据**（openclaw.json / workspace / daemon.env 已有 key 全保留）。要强覆盖运行数据加 `--force`（会备份旧 openclaw.json）。
 
 ```bash
-# 国内（默认 atomgit）
-bash -c "$(curl -fsSL https://atomgit.com/wiseflow/xiaobei/raw/branch/master/scripts/install.sh)"
-# 海外
-bash -c "$(curl -fsSL https://raw.githubusercontent.com/TeamWiseFlow/xiaobei/master/scripts/install.sh)" -s -- --github
+# macOS / Linux
+bash -c "$(curl -fsSL https://raw.githubusercontent.com/TeamWiseFlow/xiaobei/master/scripts/install.sh)"
+# Windows (PowerShell)
+irm https://raw.githubusercontent.com/TeamWiseFlow/xiaobei/master/scripts/install.ps1 | iex
 ```
 
 > 已手动 `git clone` 仓做开发的用户仍可用 `scripts/update.sh` 走 fetch + rebuild 路线（不重装依赖、不卸 daemon）。普通用户用上面的 install 脚本即可。

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -25,8 +25,9 @@ param(
     [string]$Root = "",                 # 程序目录覆盖（默认 ~\xiaobei）
     [string]$Tag = "",                  # 指定 release tag
     [string]$Tarball = "",              # 本地已下好的 tarball 路径，跳过下载
-    [string]$Mirror = "",               # 自定义镜像站根（覆盖默认 atomgit）
-    [switch]$GitHub,                    # 切回 GitHub release（不走默认 atomgit）
+    [string]$Mirror = "",               # 自定义镜像站根（覆盖默认 GitHub）
+    [switch]$GitHub,                    # 走 GitHub release（现已默认；保留向后兼容）
+    [switch]$Atomgit,                   # 切回 atomgit 国内镜像（当前 infra 不可用，待修复）
     [switch]$Force,                     # 强覆盖已有运行数据（~\.openclaw）
     [switch]$SkipBind,                  # 跳过末尾微信扫码绑定
     [switch]$SkipBrowser,               # 跳过 camoufox-cli 浏览器二进制（冒烟/CI）
@@ -41,13 +42,14 @@ if (-not $Root) {
     $Root = if ($env:XIAOBEI_HOME) { $env:XIAOBEI_HOME } else { Join-Path $env:USERPROFILE "xiaobei" }
 }
 $OpenclawHome = if ($env:OPENCLAW_HOME) { $env:OPENCLAW_HOME } else { Join-Path $env:USERPROFILE ".openclaw" }
-# 默认走 atomgit 国内镜像；-GitHub 或 XIAOBEI_SOURCE=github 切回 GitHub
+# 默认走 GitHub release（atomgit 国内镜像当前不可用：raw 返回 SPA HTML、API 被 CloudWAF 拦 418、
+# v5.6.0 资产未同步 404）。-Atomgit 或 XIAOBEI_SOURCE=atomgit 切回 atomgit（待其 infra 修复后可用）。
 $AtomgitMirror = "https://atomgit.com/wiseflow/xiaobei"
 if (-not $Mirror) {
-    if ($GitHub -or $env:XIAOBEI_SOURCE -eq "github") {
-        $env:XIAOBEI_MIRROR = ""
-    } else {
+    if ($Atomgit -or $env:XIAOBEI_SOURCE -eq "atomgit") {
         $env:XIAOBEI_MIRROR = if ($env:XIAOBEI_MIRROR) { $env:XIAOBEI_MIRROR } else { $AtomgitMirror }
+    } else {
+        $env:XIAOBEI_MIRROR = ""
     }
 } else {
     $env:XIAOBEI_MIRROR = $Mirror

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -39,13 +39,14 @@ WISEFLOW_REPO="${XIAOBEI_REPO:-TeamWiseFlow/xiaobei}"
 # 与运行数据目录 OPENCLAW_HOME（~/.openclaw：openclaw.json + daemon.env + workspace-*）分离。
 # 不隐藏：用户能直接 ls 看到，符合"小白友好"。
 WISEFLOW_ROOT_DEFAULT="${XIAOBEI_HOME:-$HOME/xiaobei}"
-# 默认走 atomgit 国内镜像（仓根），--github 或 XIAOBEI_SOURCE=github 切回 GitHub。
+# 默认走 GitHub release（atomgit 国内镜像当前不可用：raw 返回 SPA HTML、API 被 CloudWAF 拦 418、
+# v5.6.0 资产未同步 404）。--atomgit 或 XIAOBEI_SOURCE=atomgit 切回 atomgit（待其 infra 修复后可用）。
 # 资产 URL 构造为 $XIAOBEI_MIRROR/releases/download/{tag}/xiaobei-{tag}-{plat}.{tar.zst|tar.gz}
 XIAOBEI_ATOMGIT_MIRROR="https://atomgit.com/wiseflow/xiaobei"
-if [[ "${XIAOBEI_SOURCE:-}" == "github" ]]; then
-    XIAOBEI_MIRROR="${XIAOBEI_MIRROR:-}"
-else
+if [[ "${XIAOBEI_SOURCE:-}" == "atomgit" ]]; then
     XIAOBEI_MIRROR="${XIAOBEI_MIRROR:-$XIAOBEI_ATOMGIT_MIRROR}"
+else
+    XIAOBEI_MIRROR="${XIAOBEI_MIRROR:-}"
 fi
 # tarball 内 ship 的 portable Node / pnpm 入口（相对 WISEFLOW_ROOT）
 PORTABLE_NODE="tools/node/bin/node"
@@ -1215,9 +1216,15 @@ parse_args() {
                 shift
                 ;;
             --github)
-                # 切回 GitHub release（不走默认 atomgit 镜像）
+                # 走 GitHub release（现已默认；保留 flag 向后兼容）
                 XIAOBEI_SOURCE=github
                 XIAOBEI_MIRROR=""
+                shift
+                ;;
+            --atomgit)
+                # 切回 atomgit 国内镜像（当前 infra 不可用，待修复）
+                XIAOBEI_SOURCE=atomgit
+                XIAOBEI_MIRROR="$XIAOBEI_ATOMGIT_MIRROR"
                 shift
                 ;;
             --mirror)
@@ -1266,8 +1273,9 @@ Usage:
 
 Options:
   --root <dir>       Program install directory (default: ~/xiaobei; runtime data stays in ~/.openclaw)
-  --github           Use GitHub releases instead of the default atomgit mirror
-  --mirror <url>     Custom mirror root (overrides default atomgit)
+  --github           Use GitHub releases (default)
+  --atomgit          Use atomgit 国内镜像（当前 infra 不可用，待修复）
+  --mirror <url>     Custom mirror root (overrides default GitHub)
   --force            Overwrite existing runtime data (~/.openclaw); default preserves it on re-install
   --skip-bind        Skip the WeChat QR binding at the end (CI/automation)
   --skip-browser     Skip camoufox-cli browser binary install (smoke/CI, saves ~557MB Firefox)


### PR DESCRIPTION
## 实测 atomgit 三处全坏
- raw 文件接口（6 种格式全试）返回 gitcode SPA HTML（3576 字节），curl 拿不到脚本 → `bash -c` 跑 HTML
- API `/api/v1/repos/...` 被 CloudWAF 拦 418（任何 UA）
- v5.6.0 release 资产 404（只同步了 tag，没同步 140MB tarball；旧 v5.5.2 wiseflow-*.zip 还在但新 xiaobei-* 命名未同步）

GitHub 全通：raw=200/72KB 真脚本，release asset=200/147MB 真包。

## 修法
- install.sh / install.ps1 默认 GitHub（mirror 空），`--atomgit`/`-Atomgit` 改 opt-in（待 atomgit infra 修复后重新作为国内默认），`--github`/`-GitHub` 保留向后兼容
- README：GitHub 一行命令为唯一推荐（macOS/Linux bash + **Windows PowerShell**），升级段同步；atomgit 标注「修复中暂不可用」
- install.sh 加 `--atomgit` flag + 用法帮助更新

## 验证
- `bash -n` 通过；默认（无 flag）→ `XIAOBEI_MIRROR` 空（走 GitHub）✓；`--atomgit` → atomgit mirror ✓
- GitHub raw 实拉 72423 字节 `#!/bin/bash` ✓