### PR TITLE
fix(v5.6.0): win-x64 tarball 解引用 symlink + README 加微信换绑流程

### DIFF
--- a/.github/workflows/build-dist.yml
+++ b/.github/workflows/build-dist.yml
@@ -193,9 +193,16 @@ jobs:
             fi
 
             # mac/win 用 .tar.gz（bsdtar 原生支持 gzip，小白机无 zstd 二进制）；linux 用 .tar.zst（压缩率更好）
+            # win-x64 额外加 --dereference：Windows bsdtar 无法创建 symlink（哪怕 Administrator，
+            # 相对 symlink + \\?\ 前缀 → "Invalid argument"），打包时把 symlink 解引用成真实文件副本。
+            # 树内 703 个 symlink 全是相对、目标在树内、全是文件（无目录链接），解引用安全无功能损失
+            # （CLAUDE.md→AGENTS.md、rubric_notes.md→../rubric_notes.md、dist-runtime .d.ts→dist/... 都是部署态只读引用）。
             if [[ "$plat" == linux-x64 ]]; then
               ASSET="xiaobei-${TAG}-${plat}.tar.zst"
               tar --zstd -cf "$RUNNER_TEMP/out/$ASSET" -C "$PKG" .
+            elif [[ "$plat" == win-x64 ]]; then
+              ASSET="xiaobei-${TAG}-${plat}.tar.gz"
+              tar --dereference -czf "$RUNNER_TEMP/out/$ASSET" -C "$PKG" .
             else
               ASSET="xiaobei-${TAG}-${plat}.tar.gz"
               tar -czf "$RUNNER_TEMP/out/$ASSET" -C "$PKG" .

--- a/README.md
+++ b/README.md
@@ -118,6 +118,29 @@ irm https://raw.githubusercontent.com/TeamWiseFlow/xiaobei/master/scripts/instal
 
 > 排障见 [`docs/install-troubleshooting.md`](docs/install-troubleshooting.md)
 
+### 微信换绑 / 增加绑定
+
+装好后想**换一个微信号**（换绑）或**再加一个号**，都用 `channels login` 重新出二维码。`openclaw` 不在 PATH，下面命令用全路径 `~/xiaobei/bin/openclaw`（把 `~/xiaobei/bin` 加进 PATH 后可直接敲 `openclaw`）。
+
+**换绑（替换成新号）**：先停 gateway、清掉旧账号数据，再重新 login 出码：
+
+```bash
+~/xiaobei/bin/openclaw gateway stop
+rm -rf ~/.openclaw/openclaw-weixin/
+~/xiaobei/bin/openclaw gateway start
+~/xiaobei/bin/openclaw channels login --channel openclaw-weixin
+```
+
+> `channels login` 出码后 8 分钟内有效，扫码慢会自动刷新，用新微信扫一下、点确认即完成。
+
+**增加绑定（保留旧号、再加一个）**：直接再跑一次 login，用另一个微信扫：
+
+```bash
+~/xiaobei/bin/openclaw channels login --channel openclaw-weixin
+```
+
+> ⚠️ 多账号时，若两个号都能匹配同一个收件人，发消息会报 `ambiguous — N accounts matched`。所以**换号场景建议用上面的"换绑"流程清掉旧号**，避免歧义；只在确实要多号并存时用"增加绑定"。
+
 ### 升级
 
 **已装用户重跑 install 脚本即升级**：脚本检测到 `~/.openclaw/openclaw.json` 已存在时自动走更新路线——只刷新程序目录 `~/xiaobei/`（拉新 tarball + `pnpm install --prod` 重建依赖 + 幂等刷 camoufox/weixin/awada）+ restart gateway，**不碰运行数据**（openclaw.json / workspace / daemon.env 已有 key 全保留）。要强覆盖运行数据加 `--force`（会备份旧 openclaw.json）。


### PR DESCRIPTION
两个小改动合一个 PR，都属 v5.6.0 收尾。

## 1. fix(build): win-x64 tarball 解引用 symlink

**问题**：Windows `install.ps1` 解压 tarball 报
```
tar.exe: Can't create '\?\C:\Users\Administrator\xiaobei\openclaw\test\helpers\CLAUDE.md': Invalid argument
```
失败文件全是 symlink（树内 703 个 shipping symlink，bsdtar 遇到第一批就 exit 1）。

**根因**：Windows bsdtar 创建 symlink 调 `CreateSymbolicLinkW`，相对 symlink 配 `\\?\` 扩展路径前缀 → `ERROR_INVALID_PARAMETER`。哪怕 Administrator 也复现（非权限，是 Win32 API 对「相对 symlink + 扩展前缀」的兼容坑）。CI 在 Linux 上 `tar -czf` 打包，symlink 原样进 tarball，Windows 解不出。

**修法**：`.github/workflows/build-dist.yml` 给 win-x64 tarball 加 `--dereference`，打包时 symlink 解引用成真实文件副本。linux/mac 保留 symlink。前提已验：703 个 symlink 全相对、目标在树内、全文件（无目录链接、无断链）→ 解引用安全，都是部署态只读引用（`CLAUDE.md→AGENTS.md`、`dist-runtime/*.d.ts→dist/...`），副本无功能损失。

## 2. docs(readme): 加微信换绑 / 增加绑定流程

README 补「微信换绑 / 增加绑定」小节：换绑（停 gateway → 清 `~/.openclaw/openclaw-weixin/` → 重启 → `channels login`）与增加绑定（直接再 `channels login`）两流程，含多账号 `ambiguous` 歧义提醒。PATH 只一句提醒不给示例。

## 重建

合后需重建 v5.6.0（保持版本号）：先禁 Auto Release workflow 防 bump → 合 PR → 手动触发 build-dist 传 `tag=v5.6.0` → 恢复 Auto Release。