### PR TITLE
docs(readme): 补 Windows 完整步骤一行

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,8 @@ irm https://raw.githubusercontent.com/TeamWiseFlow/xiaobei/master/scripts/instal
 
 > ⚠️ **Windows 必须装 bash**（Git Bash 或 WSL）。install.ps1 用 `tar`（Win10 1803+ 自带）解压 tarball，但 `setup-crew.sh` 是 bash 脚本，部署 crew workspace 离不开 bash。无 bash 时脚本会跳过 crew 模板部署并提示手动补跑——此时小贝团队起不来。装 Git Bash：https://git-scm.com （安装时勾选 "Add to PATH"）。
 
+> 完整步骤：先装 Git Bash（安装时勾选 "Add to PATH"，让 bash 进 PowerShell 的 PATH）→ 再在 PowerShell 跑上面那条 `irm | iex`。
+
 脚本自动完成（约 5-15 分钟，CI 已预构建引擎，用户侧只 `pnpm install --prod` 拉依赖 + 下 Firefox）：
 
 1. 检测 OS + arch → 选 tarball asset（linux-x64 / mac-arm64 / mac-x64 / win-x64）


### PR DESCRIPTION
补一行 Windows 小白向的完整步骤说明：先装 Git Bash（勾 Add to PATH 让 bash 进 PowerShell PATH）→ 再跑 `irm | iex`。

这行内容此前只存在于 fork (bigbrother666sh/wiseflow) master 的一个本地 commit 里，没走 PR 进 upstream。本轮清理分支时发现，补进来免得丢。

Auto Release 已禁用，合此 PR 不 bump 版本，保持 v5.6.0。README 走 raw URL 拉取，无需重建 tarball。