### PR TITLE
docs(readme): 调试模式用 gateway run（前台）非 gateway start

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ irm https://raw.githubusercontent.com/TeamWiseFlow/xiaobei/master/scripts/instal
 
 > 🖥️ **部署机器建议**：推荐用一台 **7×24 小时常开**的电脑部署，上面**不要放置个人隐私 / 机密文件**。若你希望在日常办公电脑上安装、且只在用时启动——可以期待我们即将推出的**官方 Docker 镜像**，具体可咨询掌柜。
 
-> **调试模式**（单次启动，适合测试）：`~/xiaobei/bin/openclaw gateway start`
+> **调试模式**（前台单次启动，适合测试，不走 launchd/systemd 服务）：`~/xiaobei/bin/openclaw gateway run`
 
 > 排障见 [`docs/install-troubleshooting.md`](docs/install-troubleshooting.md)
 


### PR DESCRIPTION
核实 openclaw 源码（src/cli/daemon-cli/register-service-commands.ts）：
`gateway start/stop/restart` 走 launchd/systemd/schtasks 服务管理；
`gateway run`（src/cli/gateway-cli/register.ts:519 "Run the WebSocket Gateway (foreground)"）才是前台单次启动。

原 README「调试模式（单次启动，适合测试）：gateway start」把服务启动命令当成前台调试，在 managed install 下会启服务（和 launchd 打架/重复启）而非前台跑。改成 `gateway run`。

换绑流程里的 `gateway stop` / `gateway start` 是对的（清完 weixin 数据后重启服务），不动。

Auto Release 已禁用，不 bump 版本，保持 v5.6.0。README 走 raw URL，无需重建 tarball。