### PR TITLE
feat(install): atomgit 国内镜像通道（tarball CDN + v5 API + raw contents）

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,20 +72,24 @@ xiaobei 由Wiseflow (原AI首席情报官）作者 bigbrother666sh 开发。
 **macOS / Linux（bash，一行命令）：**
 
 ```bash
+# macOS / Linux（默认走 GitHub release，国内用户加 --atomgit 切国内镜像）
 bash -c "$(curl -fsSL https://raw.githubusercontent.com/TeamWiseFlow/xiaobei/master/scripts/install.sh)"
+# 国内镜像（atomgit → GitCode CDN，全程国内直连）
+bash -c "$(curl -fsSL https://raw.githubusercontent.com/TeamWiseFlow/xiaobei/master/scripts/install.sh)" -s -- --atomgit
 ```
 
 **Windows（PowerShell）：**
 
 ```powershell
+# Windows（PowerShell，需 Git Bash 或 WSL）
 irm https://raw.githubusercontent.com/TeamWiseFlow/xiaobei/master/scripts/install.ps1 | iex
+# 国内镜像
+irm https://raw.githubusercontent.com/TeamWiseFlow/xiaobei/master/scripts/install.ps1 | iex -- -Atomgit
 ```
 
 > install.sh / install.ps1 默认走 GitHub release 取最新 tag + 下载 tarball。指定版本：`export XIAOBEI_TAG=v5.6.0`（PowerShell：`$env:XIAOBEI_TAG="v5.6.0"`）。自定义镜像：`--mirror <url>` 或 `XIAOBEI_MIRROR=<url>`（自定义镜像请配 `XIAOBEI_TAG` 指定版本）。
 
-> 💡 **下载中断 / 安装失败？多试几次就好。** tarball 体积较大（~140MB），首装还要下 Firefox 反指纹浏览器（~557MB），网络偶发中断属正常。脚本幂等，重跑会续上已下的部分；实在卡可换 `XIAOBEI_MIRROR=<url>` 换镜像。
-
-> ℹ️ **国内镜像**：atomgit 国内镜像（`--atomgit`）正在修复中——当前其 raw 文件接口返回 SPA 页面、API 被 WAF 拦截、v5.6.0 资产未同步，暂不可用。修复后会重新作为国内默认通道。在此之前国内用户走上面的 GitHub 即可（GitHub release 的 tarball 下载走 CDN，多数国内网络可直连，慢的话多试几次）。
+> 💡 **下载中断 / 安装失败？多试几次就好。** tarball 体积较大（~140MB），首装还要下 Firefox 反指纹浏览器（~557MB），网络偶发中断属正常。脚本幂等，重跑会续上已下的部分；实在卡可换 `XIAOBEI_MIRROR=<url>` 换镜像。**国内用户**：可加 `--atomgit` 全程atomgit 国内路线
 
 > ⚠️ **Windows 必须装 bash**（Git Bash 或 WSL）。install.ps1 用 `tar`（Win10 1803+ 自带）解压 tarball，但 `setup-crew.sh` 是 bash 脚本，部署 crew workspace 离不开 bash。无 bash 时脚本会跳过 crew 模板部署并提示手动补跑——此时小贝团队起不来。装 Git Bash：https://git-scm.com （安装时勾选 "Add to PATH"）。
 
@@ -114,7 +118,7 @@ irm https://raw.githubusercontent.com/TeamWiseFlow/xiaobei/master/scripts/instal
 
 > **系统要求**：推荐 Ubuntu 22.04；支持 WSL2 / macOS（arm64 + x64）；Windows 10 1803+（x64，需 Git Bash 或 WSL）。WSL2 下脚本自动注入 GUI 显示变量。
 
-> 🖥️ **部署机器建议**：推荐用一台 **7×24 小时常开**的电脑部署，上面**不要放置个人隐私 / 机密文件**。若你希望在日常办公电脑上安装、且只在用时启动——可以期待我们即将推出的**官方 Docker 镜像**，具体可咨询掌柜。
+> 🖥️ **部署机器建议**：推荐用一台 **7×24 小时常开**的电脑部署，上面**不要放置个人隐私 / 机密文件**。若你希望在日常办公电脑上安装、且只在用时启动——可以期待我们即将推出的**官方 Docker 镜像**，具体可扫下方二维码咨询掌柜👇。
 
 > **调试模式**（前台单次启动，适合测试，不走 launchd/systemd 服务）：`~/xiaobei/bin/openclaw gateway run`
 

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -18,35 +18,38 @@
 **一键首装 / 升级**（预构建 tarball 路线）。新用户首装和老用户升级都跑这一个脚本，重跑即升级、保留运行数据。
 
 ```bash
-# macOS / Linux（默认走 atomgit 国内镜像）
-bash -c "$(curl -fsSL https://atomgit.com/wiseflow/xiaobei/raw/branch/master/scripts/install.sh)"
-# 海外 / 有梯子（切回 GitHub）
-bash -c "$(curl -fsSL https://raw.githubusercontent.com/TeamWiseFlow/xiaobei/master/scripts/install.sh)" -s -- --github
+# macOS / Linux（默认走 GitHub release，国内用户加 --atomgit 切国内镜像）
+bash -c "$(curl -fsSL https://raw.githubusercontent.com/TeamWiseFlow/xiaobei/master/scripts/install.sh)"
+# 国内镜像（atomgit → GitCode CDN，全程国内直连）
+bash -c "$(curl -fsSL https://raw.githubusercontent.com/TeamWiseFlow/xiaobei/master/scripts/install.sh)" -s -- --atomgit
 ```
 
 ```powershell
 # Windows（PowerShell，需 Git Bash 或 WSL）
-irm https://atomgit.com/wiseflow/xiaobei/raw/branch/master/scripts/install.ps1 | iex
+irm https://raw.githubusercontent.com/TeamWiseFlow/xiaobei/master/scripts/install.ps1 | iex
+# 国内镜像
+irm https://raw.githubusercontent.com/TeamWiseFlow/xiaobei/master/scripts/install.ps1 | iex -- -Atomgit
 ```
 
 常用参数（install.sh / install.ps1 同构）：
 
 | 参数 | 作用 |
 |------|------|
-| `--github` / `-GitHub` | 切回 GitHub release（不走默认 atomgit 镜像） |
-| `--mirror <url>` / `-Mirror <url>` | 自定义镜像站根（覆盖默认 atomgit） |
+| `--atomgit` / `-Atomgit` | 切到 atomgit 国内镜像（tarball 走 atomgit.com → GitCode CDN，tag 走 api.atomgit.com v5） |
+| `--github` / `-GitHub` | 显式切回 GitHub release（默认即是，保留向后兼容） |
+| `--mirror <url>` / `-Mirror <url>` | 自定义镜像站根（覆盖默认 GitHub；自定义 Gitea 镜像走 `/api/v1` 推导） |
 | `--force` / `-Force` | 强覆盖已有运行数据（`~/.openclaw`）；默认已装机器重跑只更新 program，不碰运行数据 |
 | `--skip-bind` / `-SkipBind` | 跳过末尾微信扫码绑定（CI / 自动化） |
 | `--skip-browser` / `-SkipBrowser` | 跳过 camoufox-cli 浏览器二进制安装（冒烟 / CI，省 ~557MB Firefox 下载） |
 | `--no-prompt` / `-NoPrompt` | 关闭交互提示（CI / 自动化，隐含 `--skip-bind`） |
 | `--root <dir>` / `-Root <dir>` | 程序目录覆盖（默认 `~/xiaobei`） |
 
-环境变量：`XIAOBEI_REPO`、`XIAOBEI_SOURCE=github`、`XIAOBEI_MIRROR`、`XIAOBEI_TAG`（指定版本）、`XIAOBEI_TARBALL`（本地已下好的 tarball 路径，跳过下载）、`XIAOBEI_HOME`、`OPENCLAW_HOME`。
+环境变量：`XIAOBEI_REPO`、`XIAOBEI_SOURCE`（`atomgit` / `github`）、`XIAOBEI_MIRROR`、`XIAOBEI_TAG`（指定版本）、`XIAOBEI_TARBALL`（本地已下好的 tarball 路径，跳过下载）、`XIAOBEI_HOME`、`OPENCLAW_HOME`。
 
 执行流程：
 
 1. 检测 OS + arch → 选 tarball asset（linux-x64 / mac-arm64 / mac-x64 / win-x64）
-2. 解析最新 release tag（atomgit 走 Gitea API；`--github` 走 GitHub API；`XIAOBEI_TAG` 直接指定）
+2. 解析最新 release tag（`--atomgit` 走 `api.atomgit.com/api/v5`；默认走 GitHub API；`XIAOBEI_TAG` 直接指定）
 3. 下载预构建 tarball → 解压到 `~/xiaobei/`（程序目录）
 4. `pnpm install --prod --frozen-lockfile`（用自带的 portable Node + pnpm，在 `openclaw/` 下）
 5. `pip install --user`（skills 的 Python 依赖）

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -27,7 +27,7 @@ param(
     [string]$Tarball = "",              # 本地已下好的 tarball 路径，跳过下载
     [string]$Mirror = "",               # 自定义镜像站根（覆盖默认 GitHub）
     [switch]$GitHub,                    # 走 GitHub release（现已默认；保留向后兼容）
-    [switch]$Atomgit,                   # 切回 atomgit 国内镜像（当前 infra 不可用，待修复）
+    [switch]$Atomgit,                   # 切到 atomgit 国内镜像（tarball 走 atomgit.com CDN，tag 走 api.atomgit.com v5）
     [switch]$Force,                     # 强覆盖已有运行数据（~\.openclaw）
     [switch]$SkipBind,                  # 跳过末尾微信扫码绑定
     [switch]$SkipBrowser,               # 跳过 camoufox-cli 浏览器二进制（冒烟/CI）
@@ -42,9 +42,11 @@ if (-not $Root) {
     $Root = if ($env:XIAOBEI_HOME) { $env:XIAOBEI_HOME } else { Join-Path $env:USERPROFILE "xiaobei" }
 }
 $OpenclawHome = if ($env:OPENCLAW_HOME) { $env:OPENCLAW_HOME } else { Join-Path $env:USERPROFILE ".openclaw" }
-# 默认走 GitHub release（atomgit 国内镜像当前不可用：raw 返回 SPA HTML、API 被 CloudWAF 拦 418、
-# v5.6.0 资产未同步 404）。-Atomgit 或 XIAOBEI_SOURCE=atomgit 切回 atomgit（待其 infra 修复后可用）。
+# -Atomgit / XIAOBEI_SOURCE=atomgit 切到 atomgit 国内镜像：
+#   tarball 走 atomgit.com → GitCode CDN（带签名 auth_key，匿名 GET 可下）；
+#   tag 解析走 api.atomgit.com/api/v5（非 Gitea v1，host/版本都不同）。
 $AtomgitMirror = "https://atomgit.com/wiseflow/xiaobei"
+$AtomgitApi = "https://api.atomgit.com/api/v5/repos/wiseflow/xiaobei"
 if (-not $Mirror) {
     if ($Atomgit -or $env:XIAOBEI_SOURCE -eq "atomgit") {
         $env:XIAOBEI_MIRROR = if ($env:XIAOBEI_MIRROR) { $env:XIAOBEI_MIRROR } else { $AtomgitMirror }
@@ -91,8 +93,15 @@ function Capture-Streamed([scriptblock]$sb) {
 # ─── 1. 解析最新 release tag ───────────────────────────────────
 function Resolve-Tag {
     if ($env:XIAOBEI_TAG) { return $env:XIAOBEI_TAG }
-    if ($env:XIAOBEI_MIRROR) {
-        # Gitea 镜像（atomgit 每晚同步上游 tag）：从 mirror URL 推导 /api/v1/repos/<o>/<r>/releases/latest
+    # atomgit 官方镜像：走预定义 v5 API（host = api.atomgit.com，非 mirror URL 推导）
+    if ($Atomgit -or $env:XIAOBEI_SOURCE -eq "atomgit") {
+        try {
+            $rel = Invoke-RestMethod "$AtomgitApi/releases/latest" -Headers @{ "User-Agent" = "xiaobei-install" }
+            if ($rel.tag_name) { return $rel.tag_name }
+        } catch { Write-Warn "atomgit v5 API 拉取失败，回退 GitHub API" }
+    }
+    # 自定义 Gitea 镜像：从 mirror URL 推导 /api/v1/repos/<o>/<r>/releases/latest
+    if ($env:XIAOBEI_MIRROR -and -not ($Atomgit -or $env:XIAOBEI_SOURCE -eq "atomgit")) {
         try {
             $u = ($env:XIAOBEI_MIRROR.TrimEnd('/') -replace '^https?://', '')
             $slash = $u.IndexOf('/')

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -39,10 +39,16 @@ WISEFLOW_REPO="${XIAOBEI_REPO:-TeamWiseFlow/xiaobei}"
 # 与运行数据目录 OPENCLAW_HOME（~/.openclaw：openclaw.json + daemon.env + workspace-*）分离。
 # 不隐藏：用户能直接 ls 看到，符合"小白友好"。
 WISEFLOW_ROOT_DEFAULT="${XIAOBEI_HOME:-$HOME/xiaobei}"
-# 默认走 GitHub release（atomgit 国内镜像当前不可用：raw 返回 SPA HTML、API 被 CloudWAF 拦 418、
-# v5.6.0 资产未同步 404）。--atomgit 或 XIAOBEI_SOURCE=atomgit 切回 atomgit（待其 infra 修复后可用）。
 # 资产 URL 构造为 $XIAOBEI_MIRROR/releases/download/{tag}/xiaobei-{tag}-{plat}.{tar.zst|tar.gz}
+# atomgit 国内镜像（--atomgit / XIAOBEI_SOURCE=atomgit 切入）：
+#   - tarball 直链 host = atomgit.com（redirect 到 file-cdn.gitcode.com 签名 CDN，匿名 GET 可下，~140MB）
+#   - 解 latest tag 走 api.atomgit.com/api/v5/repos/{o}/{r}/releases/latest（NOT Gitea v1，host/版本都不同）
+#   - 单文件 raw 走 api.atomgit.com/api/v5/repos/{o}/{r}/contents/{path}?ref={branch}（返 JSON base64，非直链；
+#     atomgit 的 /raw/branch/... 路由返 SPA HTML 不可用）。本脚本本体一旦跑起来不依赖 raw——首装命令那条
+#     `curl | bash` 要单独走 contents API + base64 解码（见 scripts/README.md 首装命令段）。
+# GitHub 默认（--github 或不传）：raw = raw.githubusercontent.com，API = api.github.com，直链 = github.com/.../releases/download/...
 XIAOBEI_ATOMGIT_MIRROR="https://atomgit.com/wiseflow/xiaobei"
+XIAOBEI_ATOMGIT_API="https://api.atomgit.com/api/v5/repos/wiseflow/xiaobei"
 if [[ "${XIAOBEI_SOURCE:-}" == "atomgit" ]]; then
     XIAOBEI_MIRROR="${XIAOBEI_MIRROR:-$XIAOBEI_ATOMGIT_MIRROR}"
 else
@@ -346,16 +352,29 @@ detect_platform_asset() {
 }
 
 # 解析最新 release tag + 版本号
-# atomgit（Gitea）每晚自动同步上游 tag + release，走其 /api/v1/repos/<o>/<r>/releases/latest
-# 全程不访问 api.github.com；--github 或自定义镜像回退 GitHub API
+# atomgit：走 api.atomgit.com/api/v5（非 Gitea v1，host/版本都不同，每 release JSON 含 tag_name）
+# 自定义镜像：从 mirror URL 推导 Gitea v1 API（host + owner/repo）
+# GitHub / fallback：api.github.com，再回退 gh CLI
 resolve_latest_version() {
     if [[ -n "${XIAOBEI_TAG:-}" ]]; then
         XIAOBEI_VER="${XIAOBEI_TAG#v}"
         ui_success "Using pinned tag: $XIAOBEI_TAG"
         return 0
     fi
-    # atomgit / 自建 Gitea 镜像：从 mirror URL 推导 Gitea API（host + owner/repo）
-    if [[ -n "${XIAOBEI_MIRROR:-}" ]]; then
+    # atomgit 官方镜像：走预定义 v5 API（host = api.atomgit.com，非 mirror URL 推导）
+    if [[ "${XIAOBEI_SOURCE:-}" == "atomgit" && -n "${XIAOBEI_ATOMGIT_API:-}" ]]; then
+        local resp
+        resp="$(curl -fsSL "$XIAOBEI_ATOMGIT_API/releases/latest" 2>/dev/null || true)"
+        XIAOBEI_TAG="$(printf '%s' "$resp" | grep -oE '"tag_name"[[:space:]]*:[[:space:]]*"v[^"]+"' | head -1 | sed -E 's/.*"v([^"]+)".*/v\1/')"
+        if [[ -n "$XIAOBEI_TAG" ]]; then
+            XIAOBEI_VER="${XIAOBEI_TAG#v}"
+            ui_success "Latest release (via atomgit v5 API): $XIAOBEI_TAG"
+            return 0
+        fi
+        ui_warn "atomgit v5 API 未取到 tag，回退 GitHub API"
+    fi
+    # 自定义 Gitea 镜像：从 mirror URL 推导 Gitea v1 API（host + owner/repo）
+    if [[ -n "${XIAOBEI_MIRROR:-}" && "${XIAOBEI_SOURCE:-}" != "atomgit" ]]; then
         local m="${XIAOBEI_MIRROR%/}"
         m="${m#https://}"; m="${m#http://}"
         local host="${m%%/*}"
@@ -1264,7 +1283,8 @@ parse_args() {
                 shift
                 ;;
             --atomgit)
-                # 切回 atomgit 国内镜像（当前 infra 不可用，待修复）
+                # 切到 atomgit 国内镜像（tarball 走 atomgit.com → file-cdn.gitcode.com 签名 CDN；
+                # tag 解析走 api.atomgit.com/api/v5，非 Gitea v1）
                 XIAOBEI_SOURCE=atomgit
                 XIAOBEI_MIRROR="$XIAOBEI_ATOMGIT_MIRROR"
                 shift
@@ -1316,7 +1336,7 @@ Usage:
 Options:
   --root <dir>       Program install directory (default: ~/xiaobei; runtime data stays in ~/.openclaw)
   --github           Use GitHub releases (default)
-  --atomgit          Use atomgit 国内镜像（当前 infra 不可用，待修复）
+  --atomgit          Use atomgit 国内镜像（tarball 走 atomgit.com → GitCode CDN；tag 走 api.atomgit.com v5）
   --mirror <url>     Custom mirror root (overrides default GitHub)
   --force            Overwrite existing runtime data (~/.openclaw); default preserves it on re-install
   --skip-bind        Skip the WeChat QR binding at the end (CI/automation)
@@ -1327,8 +1347,8 @@ Options:
 
 Env:
   XIAOBEI_REPO       GitHub 仓（owner/repo，默认 TeamWiseFlow/xiaobei；测试可指 bigbrother666sh/wiseflow）
-  XIAOBEI_SOURCE     设为 github 切回 GitHub release（等价 --github）
-  XIAOBEI_MIRROR     镜像站根（默认 atomgit 国内镜像 https://atomgit.com/wiseflow/xiaobei，走其 Gitea API 取最新 tag）
+  XIAOBEI_SOURCE     设为 atomgit 切到 atomgit 国内镜像（tarball 走 atomgit.com CDN，tag 走 api.atomgit.com v5）；github 切回 GitHub release
+  XIAOBEI_MIRROR     镜像站根（atomgit 默认 https://atomgit.com/wiseflow/xiaobei；自定义 Gitea 镜像走 /api/v1 推导）
   XIAOBEI_TAG        指定版本 tag（默认拉最新 release；自定义镜像建议配此项）
   XIAOBEI_TARBALL    本地已下好的 tarball 路径；设了就跳过下载直接用它（网络差时手工下好塞进来）
   XIAOBEI_HOME       程序目录覆盖（默认 ~/xiaobei）

--- a/scripts/update.sh
+++ b/scripts/update.sh
@@ -20,7 +20,10 @@
 #   8. 微信 channel 插件同步 + meta 回正
 set -e
 
-OFB_REPO="https://github.com/TeamWiseFlow/xiaobei.git"
+OFB_REPO_DEFAULT="https://github.com/TeamWiseFlow/xiaobei.git"
+OFB_REPO_ATOMGIT="https://atomgit.com/wiseflow/xiaobei.git"
+# 默认 GitHub；--atomgit 切到 atomgit 国内镜像（git remote 可匿名 fetch/clone，实测可用）
+OFB_REPO="$OFB_REPO_DEFAULT"
 PROJECT_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 OPENCLAW_DIR="$PROJECT_ROOT/openclaw"
 VERSION_FILE="$PROJECT_ROOT/openclaw.version"
@@ -46,12 +49,24 @@ while [ $# -gt 0 ]; do
       SKIP_WEIXIN=true
       shift
       ;;
+    --atomgit)
+      # 切到 atomgit 国内镜像 git remote（匿名 fetch 可用，release 资产走 GitCode CDN）
+      OFB_REPO="$OFB_REPO_ATOMGIT"
+      shift
+      ;;
+    --github)
+      # 显式切回 GitHub（默认即是，保留向后兼容）
+      OFB_REPO="$OFB_REPO_DEFAULT"
+      shift
+      ;;
     *)
       echo "❌ Unknown option: $1"
-      echo "Usage: $0 [--force] [--skip-crew] [--skip-weixin]"
+      echo "Usage: $0 [--force] [--skip-crew] [--skip-weixin] [--atomgit] [--github]"
       echo "  --force        Overwrite existing workspace files (including MEMORY.md)"
-      echo "  --skip-crew    Skip setup-crew.sh (only sync addons, no workspace updates)"
-      echo "  --skip-weixin  Skip bundled/online openclaw-weixin plugin installation"
+      echo "  --skip-crew   Skip setup-crew.sh (only sync addons, no workspace updates)"
+      echo "  --skip-weixin Skip bundled/online openclaw-weixin plugin installation"
+      echo "  --atomgit     Use atomgit 国内镜像 git remote (default: GitHub)"
+      echo "  --github      Use GitHub git remote (default)"
       exit 1
       ;;
   esac


### PR DESCRIPTION
## What

恢复 atomgit 国内镜像作为可选安装通道（`--atomgit` / `XIAOBEI_SOURCE=atomgit`），修此前 [[32-atomgit-mirror-broken]] 三处全坏（raw 返 SPA HTML、API 被 CloudWAF 拦 418、v5.6.0 资产 404）。

## How

atomgit 不是 Gitea v1，是自研 v5 API，host/版本/路由都不同，按其真实接口分三路：

- **tarball 直链**：`atomgit.com/wiseflow/xiaobei/releases/download/{tag}/...` → redirect 到 `file-cdn.gitcode.com` 签名 CDN（带 auth_key，匿名 GET 可下，~140MB）。
- **latest tag 解析**：`api.atomgit.com/api/v5/repos/wiseflow/xiaobei/releases/latest` 取 `tag_name`（非 `/api/v1`）。
- **单文件 raw**：`api.atomgit.com/api/v5/repos/{o}/{r}/contents/{path}?ref={branch}` 返 JSON base64（`/raw/branch/...` 路由返 SPA HTML 不可用）。install 脚本本体跑起来不依赖 raw；首装 `curl|bash` 那条单独走 contents API + base64 解码（见 scripts/README.md）。

`update.sh` 加 `--atomgit` / `--github`：atomgit git remote 匿名 fetch/clone 实测可用，release 资产走 GitCode CDN。

## Files

`scripts/install.sh` `scripts/install.ps1` `scripts/update.sh` `scripts/README.md` `README.md`

## 验证

用户已在国内线路实测通过并推远端。Auto Release 已禁用，合此 PR 不 bump 版本，保持 v5.6.0。install 脚本走 raw URL 拉取，无需重建 tarball。