### PR TITLE
fix(build-dist): 用完整 clone 替换浅 clone，修复 build tarball 补丁全挂

### DIFF
--- a/.github/workflows/build-dist.yml
+++ b/.github/workflows/build-dist.yml
@@ -47,11 +47,11 @@ jobs:
           version: 10.30.2
 
       - name: Clone openclaw at pinned commit
+        # 用完整 clone 而非 --depth=1 浅 clone：apply-addons.sh 跑 git apply --3way
+        # 需从 object store 读补丁头里的 pre-image blob，浅 clone 不拉 blob 会导致补丁全挂。
         run: |
-          git init openclaw
-          git -C openclaw remote add origin https://github.com/openclaw/openclaw.git
-          git -C openclaw fetch --depth=1 origin ${{ steps.pin.outputs.commit }}
-          git -C openclaw checkout FETCH_HEAD
+          git clone https://github.com/openclaw/openclaw.git openclaw
+          git -C openclaw checkout ${{ steps.pin.outputs.commit }}
 
       - name: Apply patches + pnpm install (for build)
         run: bash scripts/apply-addons.sh --no-build --no-restart --skip-crew


### PR DESCRIPTION
## 根因

build-dist.yml 的 openclaw 子仓 clone 与 #464 修的 ci.yml 同坑：`git init` + `fetch --depth=1` 裸浅 clone 不拉 blob，`apply-addons.sh` 跑 `git apply --3way` 时找不到补丁头里的 pre-image blob，`20-mod` 等 per-file 补丁全挂。

本机完整 fetch 故照跑不误，差异纯在 git 浅度。

## 修法

改用 `git clone` 完整拉取，与 ci.yml 和本机行为对齐。已在本地 `/tmp` 复现坐实。

## 验证

修法合进后手动 dispatch build-dist.yml 验证 tarball 出得来。

Co-Authored-By: AtomCode (GLM-5.2) <noreply@atomgit.com>